### PR TITLE
Add Dependabot configuration for pip updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # Python package manager
+    directory: "/" # Location of package manifests (requirements.txt)
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Introduces a .github/dependabot.yml file to enable monthly automated dependency updates for Python packages using pip.